### PR TITLE
[DEV-1672] Don't even check excluded folders for cycles

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ class CircularDependencyPlugin {
 
         const graph = webpackDependencyGraph(compilation, modules, plugin, this.options);
 
-        cycleDetector(graph, (cycle) => {
+        cycleDetector(graph, this.options, (cycle) => {
           // print modules as paths in error messages
           const cyclicalPaths = cycle.map(
             (module) => path.relative(cwd, module.resource));
@@ -123,9 +123,9 @@ function webpackDependencyGraph(compilation, modules, plugin, options) {
  *
  * The graph is acyclic iff the callback is not called.
  */
-function cycleDetector(graph, cycleCallback) {
+function cycleDetector(graph, options, cycleCallback) {
   // checking that there are no cycles is much faster than actually listing cycles
-  if (isAcyclic(graph))
+  if (isAcyclic(graph, options))
     return;
 
   /**

--- a/is-acyclic.js
+++ b/is-acyclic.js
@@ -19,10 +19,11 @@
  *
  * See https://stackoverflow.com/questions/261573/best-algorithm-for-detecting-cycles-in-a-directed-graph
  */
-function isAcyclic(graph) {
+function isAcyclic(graph, options) {
   let isAcyclic = true;
   depthFirstIterator(
     graph,
+    options,
     () => {},
     (backEdge) => isAcyclic = false);
   return isAcyclic;
@@ -35,27 +36,35 @@ function isAcyclic(graph) {
  * The visitor function is called with vertex, adjacent vertices
  * The backEdge function is called with head, tail of a back edge
  */
-function depthFirstIterator(graph, visitorFn, backEdgeFn) {
+function depthFirstIterator(graph, options, visitorFn, backEdgeFn) {
   const discovered = new Set();
   const finished = new Set();
   for (const vertex of graph.vertices) {
     if (!(discovered.has(vertex) || finished.has(vertex)))
-      depthFirstVisitor(vertex, discovered, finished, graph, visitorFn, backEdgeFn)
+      depthFirstVisitor(vertex, discovered, finished, graph, options, visitorFn, backEdgeFn)
   }
 }
 
 
-function depthFirstVisitor(vertex, discovered, finished, graph, visitorFn, backEdgeFn) {
+function depthFirstVisitor(vertex, discovered, finished, graph, options, visitorFn, backEdgeFn) {
   discovered.add(vertex)
   const adjacent = graph.arrow(vertex);  // the adjacent vertices in the direction of the edges
   visitorFn(vertex, adjacent);
 
   for (const v of adjacent) {
+    const shouldCheck = v.resource != null
+      && options.include.test(v.resource)
+      && !options.exclude.test(v.resource)
+
+    if (!shouldCheck) {
+      continue
+    }
+
     if (discovered.has(v)) {
       backEdgeFn(vertex, v);
     } else {
       if (!finished.has(v))
-        depthFirstVisitor(v, discovered, finished, graph, visitorFn, backEdgeFn)
+        depthFirstVisitor(v, discovered, finished, graph, options, visitorFn, backEdgeFn)
     }
   }
   discovered.delete(vertex)


### PR DESCRIPTION
## Backstory 

Axios@0.20.0 introduced an import cycle, https://github.com/axios/axios/issues/4463. Even though the cycle detector is configured to ignore cycles in the `node_modules`, the presence of the cycle makes the plugin slower. 

It gets slower because the plugin has two steps. In the first step, it quickly checks whether any cycles are present, which takes a few milliseconds. In the second step, the plugin makes a much bigger effort to figure out the cycle's path, which takes a few seconds. The second step won't run unless the first step found anything. However, the first step might find cycles that the second step won't report.

## Changes

This patch changes the way the cycle detecting plugin works. Right now, the plugin might quickly find a cycle and then spend a long time figuring its path without reporting it because we told the plugin to ignore cycles in that code area. With this patch applied, the plugin won't even look for cycles in the code areas we told it to ignore.

## Testing 

Without this patch, checking a project with `axios@0.20.0` installed would take 7s. With this patch applied, checking only takes 90ms as long as our code doesn't have any import cycles. However, if a cycle is introduced in our code, the processing time spikes back to 7s and the plugin reports the cycle as it should.