### PR TITLE
Fix NPM install

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "jest"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "is-acyclic.js"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Problem

When a `files` array is present in `package.json`, NPM omits all files that aren't in that array.

# Changes

This patch adds the much needed file to the `files` array so it's no omitted during NPM install